### PR TITLE
Make showing of all doc notes possible

### DIFF
--- a/client/PropertyInfoPlugin.js
+++ b/client/PropertyInfoPlugin.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 
 var elementOverlays = [];
 var overlaysVisible = true;
+var docNotesVisible = false;
 
 function PropertyInfoPlugin(eventBus, overlays, elementRegistry, editorActions) {
 
@@ -31,6 +32,12 @@ function PropertyInfoPlugin(eventBus, overlays, elementRegistry, editorActions) 
     editorActions.register({
         togglePropertyOverlays: function () {
             toggleOverlays();
+        }
+    });
+
+    editorActions.register({
+        togglePropertyDocNotes: function () {
+            toggleDocNotes();
         }
     });
 
@@ -75,6 +82,14 @@ function PropertyInfoPlugin(eventBus, overlays, elementRegistry, editorActions) 
         }
     }
 
+    function toggleDocNotes() {
+        if (overlaysVisible) {
+            docNotesVisible = !docNotesVisible;
+            overlaysVisible = false;
+            toggleOverlays();
+        }
+    }
+
     function addStyle(element) {
 
         if (elementOverlays[element.id] !== undefined && elementOverlays[element.id].length !== 0) {
@@ -93,14 +108,17 @@ function PropertyInfoPlugin(eventBus, overlays, elementRegistry, editorActions) 
             var text = element.businessObject.documentation[0].text;
             text = text.replace(/(?:\r\n|\r|\n)/g, '<br />');
 
-
+            var noteClass = "doc-val-hover";
+            if (docNotesVisible) {
+                noteClass += " doc-val-visible-note";
+            }
             elementOverlays[element.id].push(
             overlays.add(element, 'badge', {
                 position: {
                     top: 4,
                     right: 4
                 },
-                html: '<div class="doc-val-true" data-badge="D"></div><div class="doc-val-hover" data-badge="D">'+text+'</div>'
+                html: '<div class="doc-val-true" data-badge="D"><div class="'+noteClass+'" data-badge="D">'+text+'</div>'
             }));
         }
 

--- a/client/PropertyInfoPlugin.js
+++ b/client/PropertyInfoPlugin.js
@@ -118,7 +118,7 @@ function PropertyInfoPlugin(eventBus, overlays, elementRegistry, editorActions) 
                     top: 4,
                     right: 4
                 },
-                html: '<div class="doc-val-true" data-badge="D"><div class="'+noteClass+'" data-badge="D">'+text+'</div>'
+                html: '<div class="doc-val-true" data-badge="D"></div><div class="'+noteClass+'" data-badge="D">'+text+'</div>'
             }));
         }
 

--- a/client/client-bundle.js
+++ b/client/client-bundle.js
@@ -119,7 +119,7 @@ function PropertyInfoPlugin(eventBus, overlays, elementRegistry, editorActions) 
                     top: 4,
                     right: 4
                 },
-                html: '<div class="doc-val-true" data-badge="D"><div class="'+noteClass+'" data-badge="D">'+text+'</div>'
+                html: '<div class="doc-val-true" data-badge="D"></div><div class="'+noteClass+'" data-badge="D">'+text+'</div>'
             }));
         }
 

--- a/client/client-bundle.js
+++ b/client/client-bundle.js
@@ -5,6 +5,7 @@ var _ = require('lodash');
 
 var elementOverlays = [];
 var overlaysVisible = true;
+var docNotesVisible = false;
 
 function PropertyInfoPlugin(eventBus, overlays, elementRegistry, editorActions) {
 
@@ -32,6 +33,12 @@ function PropertyInfoPlugin(eventBus, overlays, elementRegistry, editorActions) 
     editorActions.register({
         togglePropertyOverlays: function () {
             toggleOverlays();
+        }
+    });
+
+    editorActions.register({
+        togglePropertyDocNotes: function () {
+            toggleDocNotes();
         }
     });
 
@@ -76,6 +83,14 @@ function PropertyInfoPlugin(eventBus, overlays, elementRegistry, editorActions) 
         }
     }
 
+    function toggleDocNotes() {
+        if (overlaysVisible) {
+            docNotesVisible = !docNotesVisible;
+            overlaysVisible = false;
+            toggleOverlays();
+        }
+    }
+
     function addStyle(element) {
 
         if (elementOverlays[element.id] !== undefined && elementOverlays[element.id].length !== 0) {
@@ -94,14 +109,17 @@ function PropertyInfoPlugin(eventBus, overlays, elementRegistry, editorActions) 
             var text = element.businessObject.documentation[0].text;
             text = text.replace(/(?:\r\n|\r|\n)/g, '<br />');
 
-
+            var noteClass = "doc-val-hover";
+            if (docNotesVisible) {
+                noteClass += " doc-val-visible-note";
+            }
             elementOverlays[element.id].push(
             overlays.add(element, 'badge', {
                 position: {
                     top: 4,
                     right: 4
                 },
-                html: '<div class="doc-val-true" data-badge="D"></div><div class="doc-val-hover" data-badge="D">'+text+'</div>'
+                html: '<div class="doc-val-true" data-badge="D"><div class="'+noteClass+'" data-badge="D">'+text+'</div>'
             }));
         }
 

--- a/menu/menu.js
+++ b/menu/menu.js
@@ -11,6 +11,16 @@ module.exports = function(electronApp, menuState) {
           action: function() {
               electronApp.emit('menu:action', 'togglePropertyOverlays');
           }
+      },
+      {
+          label: 'Toggle Doc Notes',
+          accelerator: 'Alt+N',
+          enabled: function() {
+              return menuState.bpmn;
+          },
+          action: function() {
+              electronApp.emit('menu:action', 'togglePropertyDocNotes');
+          }
       }
   ];
 };

--- a/style/style.css
+++ b/style/style.css
@@ -71,3 +71,7 @@
     overflow: hidden;
     z-index: 9999;
 }
+
+.doc-val-hover.doc-val-visible-note {
+    display: block;
+}


### PR DESCRIPTION
This impelements the feature requested in #26.

All doc notes are toggled via `Alt+N`. The switch only works if badges are displayed (use `Alt+Y` for that).